### PR TITLE
Add parameter "noSource" to avoid push of the un-minified file

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,8 +108,10 @@ module.exports = function(opt) {
 
 		this.push(min_file);
 
-		file.path = file.path.replace(/\.js$/, ext.src);
-        this.push(file);
+		if(!options.noSource) {
+			file.path = file.path.replace(/\.js$/, ext.src);
+        		this.push(file);
+		}
 		callback();
 	}
 


### PR DESCRIPTION
As a developer can be useful to output just the minified js file.

**Sample usage:**
`.pipe(minify({noSource: true}))`

With a false condition there's no differences (condition to output the source is `!options.noSource`).

_Could change the option name to "production", "debug" or "minOnly"._