### PR TITLE
Update uglify-js dependency due to security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "gulp-util": "~2.2.14",
     "minimatch": "^1.0.0",
     "through2": "~0.4.0",
-    "uglify-js": "~2.4.6"
+    "uglify-js": "^2.6.2"
   },
   "license": "ISC",
   "bugs": {


### PR DESCRIPTION
UglifyJS <2.6 is vulnerable to a regex dos attack: https://nodesecurity.io/advisories/48
It should be updated as soon as possible and published as new version to npm.