### PR TITLE
Fixed return statement in case of ignore matches.

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ module.exports = function(opt) {
 
     if (ignore || path.extname(file.path) != '.js') {
       this.push(file);
-      return;
+      return callback();
     }
 
     var mangled,


### PR DESCRIPTION
Instead of just "return;" it should contain "return callback();" otherwise scripts stops after one match an no other files will be touched/handled. Happens at least with gulp 3.9.1.