### PR TITLE
Update minimatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "taojie.hjp@taobao.com",
   "dependencies": {
     "gulp-util": "~2.2.14",
-    "minimatch": "^1.0.0",
+    "minimatch": "^3.0.2",
     "through2": "~0.4.0",
     "uglify-js": "^2.6.2"
   },


### PR DESCRIPTION
Currently installing `gulp-minify` gives a warning:

```
npm WARN deprecated minimatch@1.0.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```

This PR updates the `minimatch` dependency to the most recent version.