### PR TITLE
Upgrade to support 3.x.x versions of Gulp.

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,5 +140,5 @@ module.exports = function(opt) {
     callback();
   }
 
-  return toVinyl(through.obj(minify));
+  return toVinyl(minify);
 };

--- a/index.js
+++ b/index.js
@@ -140,5 +140,5 @@ module.exports = function(opt) {
     callback();
   }
 
-  return toVinyl(minify);
+  return minify;
 };

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ var through = require('through2'),
   path = require('path'),
   PluginError = gutil.PluginError,
   reSourceMapComment = /\n\/\/# sourceMappingURL=.+?$/,
-  pathSeparatorRe = /[\/\\]/g;
+  pathSeparatorRe = /[\/\\]/g,
+  toVinyl = require('to-vinyl');
 
 
 function parseExt(ext) {
@@ -139,5 +140,5 @@ module.exports = function(opt) {
     callback();
   }
 
-  return /*through.obj(*/minify/*)*/;
+  return toVinyl(through.obj(minify));
 };

--- a/index.js
+++ b/index.js
@@ -6,12 +6,14 @@ var through = require('through2'),
   path = require('path'),
   PluginError = gutil.PluginError,
   reSourceMapComment = /\n\/\/# sourceMappingURL=.+?$/,
-  pathSeparatorRe = /[\/\\]/g,
-  toVinyl = require('to-vinyl');
+  pathSeparatorRe = /[\/\\]/g;
+
+let Vinyl = require('vinyl');
 
 
 function parseExt(ext) {
-  var _ext = {};
+
+  let _ext = {};
 
   if (!ext) {
     _ext = {
@@ -29,16 +31,17 @@ function parseExt(ext) {
       src: ext.src || ".js"
     }
   }
+
   return _ext;
+
 }
 
 function formatError(error, file) {
-  var relativePath = '',
-    filePath = error.file === 'stdin' ? file.path : error.file,
+  let filePath = error.file === 'stdin' ? file.path : error.file,
     message = '';
 
   filePath = filePath ? filePath : file.path;
-  relativePath = path.relative(process.cwd(), filePath);
+  let relativePath = path.relative(process.cwd(), filePath);
 
   message += gutil.colors.underline(relativePath) + '\n';
   message += error.message + ' (line: ' + error.line  + ', col: ' + error.col + ', pos: ' + error.pos;
@@ -47,10 +50,16 @@ function formatError(error, file) {
 }
 
 module.exports = function(opt) {
-  var options = opt || {},
-    ext = parseExt(options.ext);
 
+  //Set the options to the one provided or an empty object.
+  let options = opt || {};
+
+  //Parse the extensions form the options.
+  let ext = parseExt(options.ext);
+
+  //Set options output to itself, or, if null an empty object.
   options.output =  options.output ||  {};
+
   function minify(file, encoding, callback) {
 
     if (file.isNull()) {
@@ -105,9 +114,14 @@ module.exports = function(opt) {
     }
     options.fromString = options.hasOwnProperty("fromString") ? options.fromString : true;
 
-    var min_file = new gutil.File({
+    /*var min_file = new gutil.File({
       path: Array.isArray(ext.min) ? file.path.replace(ext.min[0], ext.min[1]) : file.path.replace(/\.js$/, ext.min),
       base: file.base
+    });*/
+
+    let min_file = new Vinyl({
+        base: file.base,
+        path: Array.isArray(ext.min) ? file.path.replace(ext.min[0], ext.min[1]) : file.path.replace(/\.js$/, ext.min),
     });
 
     var uglifyOptions = {
@@ -137,8 +151,11 @@ module.exports = function(opt) {
       file.path = file.path.replace(/\.js$/, ext.src);
       this.push(file);
     }
+
     callback();
+
   }
 
-  return minify;
+  return through.obj(minify);
+
 };

--- a/index.js
+++ b/index.js
@@ -139,5 +139,5 @@ module.exports = function(opt) {
     callback();
   }
 
-  return through.obj(minify);
+  return /*through.obj(*/minify/*)*/;
 };

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function parseExt(ext) {
       min: "-min.js",
       src: ".js"
     }
-  } else if (typeof ext == "string") {
+  } else if (typeof ext === "string") {
     _ext = {
       min: ext,
       src: ".js"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "gulp-util": "^2.2.14",
     "minimatch": "^3.0.2",
-    "through2": "^0.4.0",
+    "through2": "^2.0.3",
     "uglify-es": "^3.0.3"
   },
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "minimatch": "^3.0.2",
     "through2": "^2.0.3",
     "uglify-es": "^3.0.3",
-    "to-vinyl": "^0.2.0"
+    "vinyl": "^2.1.0"
   },
   "license": "ISC",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "gulp-util": "^2.2.14",
     "minimatch": "^3.0.2",
     "through2": "^2.0.3",
-    "uglify-es": "^3.0.3"
+    "uglify-es": "^3.0.3",
+    "to-vinyl": "^0.2.0"
   },
   "license": "ISC",
   "bugs": {


### PR DESCRIPTION
This pull requests removes the Gulp Utils 'File' function and replaces it with Vinyl - this now makes the module compatible with later versions of Gulp. I've also updated through2 in the process.